### PR TITLE
Make showFileHeaders flag functional with diffFileHeaders(_:) modifier

### DIFF
--- a/GitDiffExample/GitDiffExample/CustomizationPlayground.swift
+++ b/GitDiffExample/GitDiffExample/CustomizationPlayground.swift
@@ -10,6 +10,7 @@ import gitdiff
 
 struct CustomizationPlayground: View {
   @State private var showLineNumbers = true
+  @State private var showFileHeaders = true
   @State private var fontSize: CGFloat = 13
   @State private var lineSpacing: DiffConfiguration.LineSpacing = .compact
   @State private var wordWrap = true
@@ -29,6 +30,7 @@ struct CustomizationPlayground: View {
           DiffRenderer(diffText: SampleDiffs.configPlaygroundDiff)
             .diffTheme(selectedTheme)
             .diffLineNumbers(showLineNumbers)
+            .diffFileHeaders(showFileHeaders)
             .diffFont(size: fontSize, weight: fontWeight)
             .diffLineSpacing(lineSpacing)
             .diffWordWrap(wordWrap)
@@ -43,6 +45,7 @@ struct CustomizationPlayground: View {
             fontSize: fontSize,
             fontWeight: fontWeight,
             lineNumbers: showLineNumbers,
+            fileHeaders: showFileHeaders,
             wordWrap: wordWrap,
             lineSpacing: lineSpacing
           )
@@ -61,6 +64,7 @@ struct CustomizationPlayground: View {
       .sheet(isPresented: $showCustomizationSheet) {
         CustomizationSheet(
           showLineNumbers: $showLineNumbers,
+          showFileHeaders: $showFileHeaders,
           fontSize: $fontSize,
           lineSpacing: $lineSpacing,
           wordWrap: $wordWrap,
@@ -83,6 +87,7 @@ struct CustomizationPlayground: View {
 
 struct CustomizationSheet: View {
   @Binding var showLineNumbers: Bool
+  @Binding var showFileHeaders: Bool
   @Binding var fontSize: CGFloat
   @Binding var lineSpacing: DiffConfiguration.LineSpacing
   @Binding var wordWrap: Bool
@@ -147,7 +152,9 @@ struct CustomizationSheet: View {
               .font(.headline)
             
             Toggle("Show Line Numbers", isOn: $showLineNumbers)
-            
+
+            Toggle("Show File Headers", isOn: $showFileHeaders)
+
             Toggle("Word Wrap", isOn: $wordWrap)
             
             VStack(alignment: .leading, spacing: 8) {
@@ -224,6 +231,7 @@ struct CustomizationSheet: View {
     withAnimation {
       selectedTheme = config.theme
       showLineNumbers = config.showLineNumbers
+      showFileHeaders = config.showFileHeaders
       fontSize = config.fontSize
       fontWeight = config.fontWeight
       lineSpacing = config.lineSpacing
@@ -234,6 +242,7 @@ struct CustomizationSheet: View {
   private func resetToDefaults() {
     withAnimation {
       showLineNumbers = true
+      showFileHeaders = true
       fontSize = 13
       lineSpacing = .compact
       wordWrap = true
@@ -271,6 +280,7 @@ struct ConfigurationSummary: View {
   let fontSize: CGFloat
   let fontWeight: Font.Weight
   let lineNumbers: Bool
+  let fileHeaders: Bool
   let wordWrap: Bool
   let lineSpacing: DiffConfiguration.LineSpacing
   
@@ -284,6 +294,7 @@ struct ConfigurationSummary: View {
         ConfigItem(label: "Font Size", value: "\(Int(fontSize))pt")
         ConfigItem(label: "Font Weight", value: fontWeightName)
         ConfigItem(label: "Line Numbers", value: lineNumbers ? "On" : "Off")
+        ConfigItem(label: "File Headers", value: fileHeaders ? "On" : "Off")
         ConfigItem(label: "Word Wrap", value: wordWrap ? "On" : "Off")
         ConfigItem(label: "Line Spacing", value: lineSpacingName)
       }

--- a/GitDiffExample/GitDiffExample/ExamplesView.swift
+++ b/GitDiffExample/GitDiffExample/ExamplesView.swift
@@ -210,6 +210,7 @@ struct ExampleDetailView: View {
   @Environment(\.dismiss) var dismiss
   @State private var selectedTheme: DiffTheme = .light
   @State private var showLineNumbers = true
+  @State private var showFileHeaders = true
   
   var body: some View {
     NavigationView {
@@ -240,6 +241,7 @@ struct ExampleDetailView: View {
         // Controls
         HStack {
           Toggle("Line Numbers", isOn: $showLineNumbers)
+          Toggle("File Headers", isOn: $showFileHeaders)
           Spacer()
           Button(action: shareExample) {
             Image(systemName: "square.and.arrow.up")
@@ -253,6 +255,7 @@ struct ExampleDetailView: View {
           DiffRenderer(diffText: example.diffContent)
             .diffTheme(selectedTheme)
             .diffLineNumbers(showLineNumbers)
+            .diffFileHeaders(showFileHeaders)
             .padding()
         }
       }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ For reusable configurations:
 let codeReviewConfig = DiffConfiguration(
     theme: .light,
     showLineNumbers: true,
+    showFileHeaders: true,
     fontSize: 13,
     fontWeight: .regular,
     lineSpacing: .comfortable,
@@ -201,6 +202,7 @@ struct PullRequestView: View {
 
 - `.diffTheme(_ theme: DiffTheme)` - Apply a color theme
 - `.diffLineNumbers(_ show: Bool)` - Toggle line numbers
+- `.diffFileHeaders(_ show: Bool)` - Toggle file headers
 - `.diffFont(size: CGFloat?, weight: Font.Weight?, design: Font.Design?)` - Configure font
 - `.diffLineSpacing(_ spacing: LineSpacing)` - Set line spacing
 - `.diffWordWrap(_ wrap: Bool)` - Enable word wrapping

--- a/Sources/gitdiff/DiffConfigurationBuilder.swift
+++ b/Sources/gitdiff/DiffConfigurationBuilder.swift
@@ -66,6 +66,22 @@ public extension DiffConfiguration {
         )
     }
     
+    /// Creates a new configuration with file headers toggled
+    func withFileHeaders(_ show: Bool) -> DiffConfiguration {
+        DiffConfiguration(
+            theme: theme,
+            showLineNumbers: showLineNumbers,
+            showFileHeaders: show,
+            fontFamily: fontFamily,
+            fontSize: fontSize,
+            fontWeight: fontWeight,
+            lineHeight: lineHeight,
+            lineSpacing: lineSpacing,
+            wordWrap: wordWrap,
+            contentPadding: contentPadding
+        )
+    }
+
     /// Creates a new configuration with word wrap toggled
     func withWordWrap(_ wrap: Bool) -> DiffConfiguration {
         DiffConfiguration(

--- a/Sources/gitdiff/DiffEnvironment.swift
+++ b/Sources/gitdiff/DiffEnvironment.swift
@@ -60,7 +60,26 @@ public extension View {
             )
         }
     }
-    
+
+    /// Shows or hides file headers.
+    /// - Parameter show: Whether to show file headers
+    func diffFileHeaders(_ show: Bool) -> some View {
+        transformEnvironment(\.diffConfiguration) { config in
+            config = DiffConfiguration(
+                theme: config.theme,
+                showLineNumbers: config.showLineNumbers,
+                showFileHeaders: show,
+                fontFamily: config.fontFamily,
+                fontSize: config.fontSize,
+                fontWeight: config.fontWeight,
+                lineHeight: config.lineHeight,
+                lineSpacing: config.lineSpacing,
+                wordWrap: config.wordWrap,
+                contentPadding: config.contentPadding
+            )
+        }
+    }
+
     /// Configures font properties.
     /// - Parameters:
     ///   - size: Font size

--- a/Sources/gitdiff/Views/DiffFileView.swift
+++ b/Sources/gitdiff/Views/DiffFileView.swift
@@ -15,29 +15,31 @@ struct DiffFileView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack {
-        Image(systemName: "doc.text")
-          .foregroundColor(configuration.theme.fileHeaderText)
+      if configuration.showFileHeaders {
+        HStack {
+          Image(systemName: "doc.text")
+            .foregroundColor(configuration.theme.fileHeaderText)
 
-        Text(file.displayName)
-          .font(.system(.headline, design: configuration.fontFamily))
-          .fontWeight(.bold)
-          .foregroundColor(configuration.theme.fileHeaderText)
+          Text(file.displayName)
+            .font(.system(.headline, design: configuration.fontFamily))
+            .fontWeight(.bold)
+            .foregroundColor(configuration.theme.fileHeaderText)
 
-        Spacer()
+          Spacer()
 
-        if file.isBinary {
-          Text("Binary file")
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 2)
-            .background(Color.secondary.opacity(0.2))
-            .cornerRadius(4)
+          if file.isBinary {
+            Text("Binary file")
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .padding(.horizontal, 8)
+              .padding(.vertical, 2)
+              .background(Color.secondary.opacity(0.2))
+              .cornerRadius(4)
+          }
         }
+        .padding()
+        .background(configuration.theme.fileHeaderBackground)
       }
-      .padding()
-      .background(configuration.theme.fileHeaderBackground)
 
       if file.isBinary {
         Text("Binary file not shown")


### PR DESCRIPTION
@tornikegomareli great project, thanks for open sourcing it!

## Summary

The `showFileHeaders` flag in `DiffConfiguration` existed but was never consulted — file headers were always rendered. This PR makes it work, exposes it as a first-class view modifier, and documents it.

## Changes

- `DiffFileView`: conditionally render the file header based on `configuration.showFileHeaders`
- `DiffEnvironment`: add public `diffFileHeaders(_:)` view modifier, matching the ergonomics of `diffLineNumbers(_:)`
- `DiffConfigurationBuilder`: add `withFileHeaders(_:)` builder method for consistency with the rest of the builder API
- `README`: add `.diffFileHeaders(_:)` to the modifiers list and `showFileHeaders` to the configuration object example
- Example app: surface a toggle in both `CustomizationPlayground` and `ExamplesView`

## Testing

Verified manually via the example app — toggling the control in both the Customization Playground and Examples view shows/hides file headers as expected.

| Before | After |
| ---- | ---- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-24 at 23 36 54" src="https://github.com/user-attachments/assets/a4b2d889-35d6-463c-b7ee-aeb1de05b8f6" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-24 at 23 36 27" src="https://github.com/user-attachments/assets/ccc5c4b5-e091-4a94-973c-e4d908ede782" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "File Headers" toggle to show or hide file header lines in diffs
  * New `.diffFileHeaders()` view modifier for controlling header visibility in the configuration chain
  * File headers visibility now configurable via customization UI and presets

* **Documentation**
  * Updated README with examples demonstrating the new file headers configuration option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->